### PR TITLE
Cpg 46 create g UI for adding a base exercise

### DIFF
--- a/Duo/Duo.csproj
+++ b/Duo/Duo.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <None Remove="Views\Components\QuizAdminButton.xaml" />
     <None Remove="Views\Pages\AdminMainPage.xaml" />
+    <None Remove="Views\Pages\CreateExercisePage.xaml" />
     <None Remove="Views\Pages\RoadmapMainPage.xaml" />
   </ItemGroup>
 
@@ -43,6 +44,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250310001" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\Pages\CreateExercisePage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Page Update="Views\Components\QuizAdminButton.xaml">

--- a/Duo/Views/Pages/AdminMainPage.xaml
+++ b/Duo/Views/Pages/AdminMainPage.xaml
@@ -26,11 +26,18 @@
                    FontWeight="SemiBold"  
                    FontSize="32"/>
 
+                <!-- Horizontal Line -->
+                <Rectangle Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" 
+                  Height="1" 
+                  Margin="0,0,0,6"
+                  Fill="{ThemeResource SystemControlForegroundBaseLowBrush}" 
+                  HorizontalAlignment="Stretch"/>
+
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <components:QuizAdminButton Text="Create section"/>
                     <components:QuizAdminButton Text="Create quiz"/>
                     <components:QuizAdminButton Text="Create exam"/>
-                    <components:QuizAdminButton Text="Create exercise"/>
+                    <components:QuizAdminButton Text="Create exercise" Click="OpenCreateExamPage_Click"/>
                 </StackPanel>
 
                 <StackPanel Orientation="Horizontal" Spacing="12">

--- a/Duo/Views/Pages/CreateExercisePage.xaml
+++ b/Duo/Views/Pages/CreateExercisePage.xaml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="Duo.Views.Pages.CreateExercisePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Duo.Views.Pages"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:components="using:Duo.Views.Components"
+    HorizontalAlignment="Stretch">
+
+    <Grid  HorizontalAlignment="Stretch" MaxWidth="900" Margin="32,0,32,0">
+        <ScrollViewer
+            HorizontalAlignment="Stretch" 
+            HorizontalContentAlignment="Stretch"
+            VerticalScrollBarVisibility="Auto"
+            Padding="0,16,0,16">
+            <StackPanel
+                HorizontalAlignment="Stretch"
+                MaxWidth="900"
+                Spacing="16">
+            <!-- Back Button -->
+                <Button 
+                        x:Name="BackButton"
+                        Content="Back"
+                        Click="BackButton_Click"
+                        Margin="0,16,0,16"/>
+            
+            
+                <ComboBox SelectionChanged="ExerciseComboBox_SelectionChanged" Header="Exercise type" PlaceholderText="Pick an exercise type" Width="200">
+                    <x:String>Association</x:String>
+                    <x:String>Fill in the blank</x:String>
+                    <x:String>Multiple Choice</x:String>
+                    <x:String>Flashcard</x:String>
+                </ComboBox>
+
+                <StackPanel Spacing="8">
+                    <TextBlock Text="Question"></TextBlock>
+                    <TextBox 
+                            x:Name="QuestionTextBox"
+                            Grid.Column="0"
+                            PlaceholderText="Write the question here..." 
+                            FontSize="12" 
+                            HorizontalAlignment="Left"
+                            BorderThickness="0"
+                            Background="Transparent"
+                            Margin="0,0,8,0"
+                            Text="{x:Bind QuestionText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                            TextWrapping="Wrap"
+                            AcceptsReturn="True"
+                            MaxHeight="100"
+                        Width="400"/>
+                </StackPanel>
+
+                <StackPanel
+                        Orientation="Horizontal" Spacing="12">
+                        <Button 
+                             x:Name="CancelButton"
+                             Content="Cancel"
+                             Click="CancelButton_Click"
+                             Margin="0,16,0,16"/>
+                        <Button 
+                            x:Name="SaveButton"
+                            Content="Save"
+                            Click="SaveButton_Click"
+                            Margin="0,16,0,16"/>
+                    </StackPanel>
+                </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/Duo/Views/Pages/CreateExercisePage.xaml.cs
+++ b/Duo/Views/Pages/CreateExercisePage.xaml.cs
@@ -21,16 +21,46 @@ namespace Duo.Views.Pages
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class AdminMainPage : Page
+    public sealed partial class CreateExercisePage : Page
     {
-        public AdminMainPage()
+        private string _questionText = string.Empty;
+        public CreateExercisePage()
         {
             this.InitializeComponent();
         }
 
-        public void OpenCreateExamPage_Click(object sender, RoutedEventArgs e)
+        public void ExerciseComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            Frame.Navigate(typeof(CreateExercisePage));
+
         }
+        public void BackButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (this.Frame.CanGoBack)
+            {
+                this.Frame.GoBack();
+            }
+        }
+
+        public string QuestionText
+        {
+            get => _questionText;
+            set
+            {
+                _questionText = value;
+            }
+        }
+
+        public void CancelButton_Click(object senderm, RoutedEventArgs e)
+        {
+
+        }
+
+
+        public void SaveButton_Click(object senderm, RoutedEventArgs e)
+        {
+
+        }
+
     }
 }
+


### PR DESCRIPTION
This pull request introduces a new `CreateExercisePage` and integrates it into the existing project. The changes include updates to the project file, the addition of the new page, and modifications to the `AdminMainPage` to link to the new page.

### Integration of `CreateExercisePage`:

* **Project File Updates:**
  * Added `CreateExercisePage.xaml` to the list of removed files in `Duo.csproj`.
  * Included `CreateExercisePage.xaml` in the `Page` item group for compilation in `Duo.csproj`.

* **`AdminMainPage` Modifications:**
  * Added a horizontal line for visual separation in `AdminMainPage.xaml`.
  * Updated the "Create exercise" button to navigate to `CreateExercisePage` in `AdminMainPage.xaml`.
  * Added the `OpenCreateExamPage_Click` method to handle navigation to `CreateExercisePage` in `AdminMainPage.xaml.cs`.

* **New `CreateExercisePage`:**
  * Added the `CreateExercisePage.xaml` file with UI elements including a back button, exercise type combo box, question text box, and save/cancel buttons.
  * Implemented the `CreateExercisePage.xaml.cs` file with basic event handlers for UI interactions.